### PR TITLE
Fix 404 Not Found

### DIFF
--- a/.github/workflows/juce_plugin_ci.yml
+++ b/.github/workflows/juce_plugin_ci.yml
@@ -46,6 +46,7 @@ jobs:
       name: Install JUCE dependencies (Linux only)
       id: juce_dependencies
       run: | 
+        sudo apt-get update
         sudo apt-get install -y g++ libgtk-3-dev libfreetype6-dev libx11-dev libxinerama-dev libxrandr-dev libxcursor-dev mesa-common-dev libasound2-dev freeglut3-dev libxcomposite-dev libcurl4-openssl-dev
         sudo add-apt-repository -y ppa:webkit-team && sudo apt-get update
         sudo apt-get install libwebkit2gtk-4.0-37 libwebkit2gtk-4.0-dev


### PR DESCRIPTION
Was getting this error in the `Install JUCE Dependencies` step of the Ubuntu build:
```
Fetched 4553 kB in 0s (9443 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_21.0.3-0ubuntu0.2~20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-dev_21.0.3-0ubuntu0.2~20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl1-mesa-dev_21.0.3-0ubuntu0.2~20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/mesa-common-dev_21.0.3-0ubuntu0.2~20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
This seems to be fixed by calling `sudo apt-get update` before installing dependencies.